### PR TITLE
Improve fullscreen handling and mobile menu

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -3,4 +3,5 @@
     <name>Wisprunner</name>
     <content src="index.html" />
     <preference name="Orientation" value="landscape" />
+    <preference name="Fullscreen" value="true" />
 </widget>

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -17,8 +17,9 @@ body.game {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  position: relative;
+  justify-content: flex-start;
+  padding: 2vmin;
+  overflow: hidden;
 }
 
 #startBtn,
@@ -30,6 +31,7 @@ body.game {
   cursor: pointer;
 }
 
+
 .menu-button {
   width: min(80vw, 300px);
   height: auto;
@@ -38,20 +40,17 @@ body.game {
 }
 
 #buttonCluster {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 2vmin;
+  width: 100%;
+  flex-grow: 1;
 }
 
 #buttonCluster .menu-button {
-  width: min(15vmin, 160px);
-  margin: 1vmin 0;
+  width: min(60vw, 300px);
+  margin: 1.5vmin 0;
 }
 
 #gameContainer {
@@ -93,20 +92,18 @@ body.game {
 }
 
 #scores {
-  position: absolute;
-  top: 10px;
-  left: 10px;
+  width: 100%;
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  margin-bottom: 20px;
+  justify-content: space-around;
+  margin-bottom: 2vmin;
+  position: static;
 }
 
 .scoreTable {
-  width: 150px;
+  width: 40%;
+  max-width: 180px;
   background: rgba(255,255,255,0.5);
   padding: 10px;
-  margin-bottom: 10px;
 }
 
 #gameOver {

--- a/www/js/orientation.js
+++ b/www/js/orientation.js
@@ -4,6 +4,18 @@ document.addEventListener('DOMContentLoaded', () => {
       screen.orientation.lock('landscape').catch(() => {});
     }
   };
+
+  const goFull = () => {
+    const el = document.documentElement;
+    if (el.requestFullscreen) {
+      el.requestFullscreen().catch(() => {});
+    } else if (el.webkitRequestFullscreen) {
+      el.webkitRequestFullscreen();
+    }
+  };
+
+  document.body.addEventListener('click', goFull, { once: true });
+
   lock();
   document.addEventListener('deviceready', lock);
   window.addEventListener('orientationchange', lock);

--- a/www/manifest.json
+++ b/www/manifest.json
@@ -2,7 +2,7 @@
   "name": "RuneDream",
   "short_name": "RuneDream",
   "start_url": "index.html",
-  "display": "standalone",
+  "display": "fullscreen",
   "orientation": "landscape",
   "background_color": "#89ABE3",
   "theme_color": "#89ABE3",


### PR DESCRIPTION
## Summary
- Request fullscreen on first interaction and lock landscape orientation
- Enlarge and re-center menu buttons for a mobile-friendly layout
- Configure app to launch in fullscreen via manifest and Cordova prefs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ec6116a2c8330bafbdd4f00dcf9b5