### PR TITLE
Improve opening menu on mobile

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -19,7 +19,7 @@ body.game {
   align-items: center;
   justify-content: flex-start;
   padding: 2vmin;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 #startBtn,
@@ -41,7 +41,7 @@ body.game {
 
 #buttonCluster {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
   width: 100%;
@@ -49,8 +49,8 @@ body.game {
 }
 
 #buttonCluster .menu-button {
-  width: min(60vw, 300px);
-  margin: 1.5vmin 0;
+  width: min(45vw, 180px);
+  margin: 1.5vmin;
 }
 
 #gameContainer {


### PR DESCRIPTION
## Summary
- Allow landing menu buttons to wrap into multiple rows
- Enable scrolling on landing screen so all buttons remain accessible

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_688ec8da35f88330a3e638ee251fd216