### PR TITLE
Adjust landing button layout

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -41,16 +41,17 @@ body.game {
 
 #buttonCluster {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   width: 100%;
   flex-grow: 1;
+  margin-top: 20vh;
 }
 
 #buttonCluster .menu-button {
-  width: min(45vw, 180px);
-  margin: 1.5vmin;
+  width: min(60vw, 300px);
+  margin: 1.5vmin 0;
 }
 
 #gameContainer {


### PR DESCRIPTION
## Summary
- Stack menu buttons vertically and add top margin so they don't cover the title screen background

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fbd91f95883309ed9f794c74eb6fd