### PR TITLE
Arrange landing buttons along bottom

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -20,6 +20,7 @@ body.game {
   justify-content: flex-start;
   padding: 2vmin;
   overflow-y: auto;
+  position: relative;
 }
 
 #startBtn,
@@ -52,6 +53,26 @@ body.game {
 #buttonCluster .menu-button {
   width: min(60vw, 300px);
   margin: 1.5vmin 0;
+}
+
+@media (orientation: landscape) {
+  #buttonCluster {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-end;
+    position: absolute;
+    bottom: 5vh;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 90vw;
+    margin-top: 0;
+  }
+
+  #buttonCluster .menu-button {
+    width: 18vw;
+    max-width: 140px;
+    margin: 0;
+  }
 }
 
 #gameContainer {

--- a/www/index.html
+++ b/www/index.html
@@ -30,7 +30,6 @@
       <img id="shopBtn" class="menu-button" src="assets/button_upgradeshop.png" alt="Upgrade Shop">
       <img id="resetBtn" class="menu-button" src="assets/button_resetprogress.png" alt="Reset Progress">
       <img id="settingsBtn" class="menu-button" src="assets/button_settings.png" alt="Settings">
-      <img id="exitBtn" class="menu-button" src="assets/button_exitgame.png" alt="Exit Game">
     </div>
   </div>
   <script>
@@ -45,9 +44,6 @@
     });
     document.getElementById('settingsBtn').addEventListener('click', () => {
       window.location.href = 'settings.html';
-    });
-    document.getElementById('exitBtn').addEventListener('click', () => {
-      window.close();
     });
     document.getElementById('resetBtn').addEventListener('click', () => {
       localStorage.setItem('coins', '0');


### PR DESCRIPTION
## Summary
- lay out all five landing buttons in a horizontal row and remove the extra exit option
- anchor the cluster beneath the title and fit each button to evenly fill the bottom of the landscape screen

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc166ef788330bd07702a58d23a13