### PR TITLE
Refine menu layout and pacing

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -19,7 +19,7 @@ body.game {
   align-items: center;
   justify-content: flex-start;
   padding: 2vmin;
-  overflow-y: auto;
+  overflow: hidden;
   position: relative;
 }
 
@@ -42,37 +42,21 @@ body.game {
 
 #buttonCluster {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  flex-grow: 1;
-  margin-top: 20vh;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-end;
+  position: absolute;
+  bottom: 5vh;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 90vw;
+  margin-top: 0;
 }
 
 #buttonCluster .menu-button {
-  width: min(60vw, 300px);
-  margin: 1.5vmin 0;
-}
-
-@media (orientation: landscape) {
-  #buttonCluster {
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: flex-end;
-    position: absolute;
-    bottom: 5vh;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 90vw;
-    margin-top: 0;
-  }
-
-  #buttonCluster .menu-button {
-    width: 18vw;
-    max-width: 140px;
-    margin: 0;
-  }
+  width: 18vw;
+  max-width: 140px;
+  margin: 0;
 }
 
 #gameContainer {

--- a/www/js/game.js
+++ b/www/js/game.js
@@ -117,7 +117,7 @@ const INPUT = {
   jumpHeld: false
 };
 
-const BASE_SPEED = 4;
+const BASE_SPEED = 2;
 const GAME = {
   speed: BASE_SPEED,
   gravity: 0.5,
@@ -357,11 +357,8 @@ function showRespawnCountdown() {
 
 function update() {
   if (!GAME.player.alive) return;
-  const level = Math.floor(GAME.distance / 5000);
-  if (level > GAME.difficultyLevel) {
-    GAME.difficultyLevel = level;
-    GAME.speed = BASE_SPEED + GAME.difficultyLevel * 0.5;
-  }
+  GAME.difficultyLevel = Math.floor(GAME.distance / 5000);
+  GAME.speed = BASE_SPEED + GAME.distance / 10000;
   if (GAME.mode === 'time') {
     GAME.timer--;
     if (GAME.timer <= 0) {


### PR DESCRIPTION
## Summary
- Arrange menu buttons in a fixed row along the bottom of the landing page
- Start gameplay at half speed and gradually accelerate over distance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a616dfbfb88330b32eaa00ccb99619