### PR TITLE
Slow player's fall after jumps

### DIFF
--- a/www/js/game.js
+++ b/www/js/game.js
@@ -387,7 +387,8 @@ function update() {
       GAME.player.dashBuffer--;
     }
     const prevY = GAME.player.y;
-    GAME.player.vy += GAME.gravity;
+    const gravityEffect = GAME.player.vy > 0 ? GAME.gravity / 2 : GAME.gravity;
+    GAME.player.vy += gravityEffect;
     GAME.player.y += GAME.player.vy;
     const groundLevel = getGroundLevel(GAME.player.x + GAME.player.width / 2) - 20;
     if (GAME.player.vy >= 0 && prevY <= groundLevel && GAME.player.y >= groundLevel) {


### PR DESCRIPTION
## Summary
- Halve gravity effect when the player is descending to slow fall speed and extend airtime

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/wisprunner/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bca7e8484083308aca8aea2dc5e3c8