### PR TITLE
Refine upgrade shop layout for mobile

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -154,3 +154,46 @@ body.game {
   color: gold;
   margin-left: 5px;
 }
+
+#shop ul {
+  list-style: none;
+  padding: 0;
+  width: 90%;
+  max-width: 500px;
+}
+
+.shop-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 10px 0;
+  width: 100%;
+}
+
+.upgrade-description {
+  flex: 1;
+  text-align: left;
+  margin-right: 10px;
+}
+
+.shop-button {
+  background: #ffb347;
+  border: none;
+  border-radius: 12px;
+  padding: 10px 20px;
+  font-size: 1.1em;
+  color: #fff;
+  box-shadow: 0 4px #e69500;
+  cursor: pointer;
+}
+
+.shop-button:active {
+  box-shadow: 0 2px #e69500;
+  transform: translateY(2px);
+}
+
+.shop-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}

--- a/www/upgrade.html
+++ b/www/upgrade.html
@@ -16,34 +16,36 @@
   <div id="shop">
     <h1>Upgrade Shop</h1>
     <p>Coins: <span id="coinDisplay">0</span></p>
-    <ul>
-      <li>
-        Add a Jump Charge <span id="jumpStars" class="stars"></span> - <span class="cost"></span> coins
-        <button id="jumpBtn">Buy</button>
+    <ul class="upgrade-list">
+      <li class="shop-item">
+        <span class="upgrade-description">Add a Jump Charge <span id="jumpStars" class="stars"></span> - <span class="cost"></span> coins</span>
+        <button id="jumpBtn" class="shop-button">Buy</button>
       </li>
-      <li>
-        Add a Dash Charge <span id="dashStars" class="stars"></span> - <span class="cost"></span> coins
-        <button id="dashBtn">Buy</button>
+      <li class="shop-item">
+        <span class="upgrade-description">Add a Dash Charge <span id="dashStars" class="stars"></span> - <span class="cost"></span> coins</span>
+        <button id="dashBtn" class="shop-button">Buy</button>
       </li>
-      <li>
-        Add a Shield Charge <span id="shieldStars" class="stars"></span> - <span class="cost"></span> coins
-        <button id="shieldBtn">Buy</button>
+      <li class="shop-item">
+        <span class="upgrade-description">Add a Shield Charge <span id="shieldStars" class="stars"></span> - <span class="cost"></span> coins</span>
+        <button id="shieldBtn" class="shop-button">Buy</button>
       </li>
-      <li>
-        Increase Jump Height <span id="jumpHeightStars" class="stars"></span> - <span class="cost"></span> coins
-        <button id="jumpHeightBtn">Buy</button>
+      <li class="shop-item">
+        <span class="upgrade-description">Increase Jump Height <span id="jumpHeightStars" class="stars"></span> - <span class="cost"></span> coins</span>
+        <button id="jumpHeightBtn" class="shop-button">Buy</button>
       </li>
-      <li>
-        Increase Dash Duration <span id="dashDurationStars" class="stars"></span> - <span class="cost"></span> coins
-        <button id="dashDurationBtn">Buy</button>
+      <li class="shop-item">
+        <span class="upgrade-description">Increase Dash Duration <span id="dashDurationStars" class="stars"></span> - <span class="cost"></span> coins</span>
+        <button id="dashDurationBtn" class="shop-button">Buy</button>
       </li>
-      <li>
-        Gain an Extra Life <span id="lifeStars" class="stars"></span> - <span class="cost"></span> coins
-        <button id="lifeBtn">Buy</button>
+      <li class="shop-item">
+        <span class="upgrade-description">Gain an Extra Life <span id="lifeStars" class="stars"></span> - <span class="cost"></span> coins</span>
+        <button id="lifeBtn" class="shop-button">Buy</button>
       </li>
     </ul>
-    <button id="refundBtn">Refund all Coins</button>
-    <button id="backBtn">Back</button>
+    <div class="shop-actions">
+      <button id="refundBtn" class="shop-button">Refund all Coins</button>
+      <button id="backBtn" class="shop-button">Back</button>
+    </div>
   </div>
   <script src="js/upgrade.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- Reworked upgrade list markup to separate descriptions and Buy buttons for proper left/right alignment
- Introduced mobile-focused styles and button theme matching main menu

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bcac09169c83308becfbbab5180851